### PR TITLE
Add missing MATLAB binding helpers

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -34,17 +34,14 @@ pkg_check_modules(UFO REQUIRED ufo>=0.12)
 # ---------------------------------------------------------------------------
 # 3.  Source lists  ( **updated** )
 # ---------------------------------------------------------------------------
-set(MEX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/matlab/mex")   # <-- adjust here if needed
+set(MEX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/matlab/src")
 
-file(GLOB_RECURSE MEX_SRC   "${MEX_DIR}/*.c")
-file(GLOB_RECURSE API_HDR   "${MEX_DIR}/include/*.h")
-
-# Abort early with a clear message if we glob the wrong place
-if (MEX_SRC STREQUAL "")
-    message(FATAL_ERROR
-        "No .c source files found in ${MEX_DIR}. "
-        "Make sure the MATLAB bindings live there or update MEX_DIR.")
-endif ()
+set(MEX_SRC
+    "${MEX_DIR}/ufo_mex.c"
+    "${MEX_DIR}/ufo_commands.c"
+    "${MEX_DIR}/ufo_buffer.c"
+    "${MEX_DIR}/mexUfo_handle.c")
+file(GLOB_RECURSE API_HDR   "${CMAKE_CURRENT_SOURCE_DIR}/matlab/include/*.h")
 
 # ---------------------------------------------------------------------------
 # 4.  Build the MEX gateway (libufo_mex.${Matlab_MEX_EXTENSION})
@@ -54,7 +51,7 @@ add_library(ufo_mex SHARED ${MEX_SRC} ${API_HDR})
 target_include_directories(ufo_mex PRIVATE
         ${Matlab_INCLUDE_DIRS}
         ${UFO_INCLUDE_DIRS}
-        "${MEX_DIR}/include")
+        "${CMAKE_CURRENT_SOURCE_DIR}/matlab/include")
 
 # Needed by every MEX source
 target_compile_definitions(ufo_mex PRIVATE MATLAB_MEX_FILE)

--- a/matlab/include/mexUfo_handle.h
+++ b/matlab/include/mexUfo_handle.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <mex.h>
+#include <ufo/ufo.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mexUfo_handle_init(void);
+void mexUfo_handle_shutdown(void);
+
+mxArray *ufoHandle_create(gpointer obj, const char *type_name);
+void ufoHandle_remove(const mxArray *arr);
+
+UfoBuffer        *ufoHandle_getBuffer(const mxArray *arr);
+UfoPluginManager *ufoHandle_getPluginManager(const mxArray *arr);
+UfoTaskGraph     *ufoHandle_getTaskGraph(const mxArray *arr);
+UfoBaseScheduler *ufoHandle_getScheduler(const mxArray *arr);
+UfoTask          *ufoHandle_getTask(const mxArray *arr);
+UfoResources     *ufoHandle_getResources(const mxArray *arr);
+
+/* Compatibility wrapper used by older sources */
+mxArray *createUfoHandle(UFO_Handle handle, const char *className);
+
+#ifdef __cplusplus
+}
+#endif

--- a/matlab/include/ufo_mex_api.h
+++ b/matlab/include/ufo_mex_api.h
@@ -29,6 +29,10 @@ void UFO_pm_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
 ///  t = ufo_mex('pm_getTask', h, taskName);
 void UFO_pm_getTask(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
 
+/// UFO_pm_listPlugins()
+///  names = ufo_mex('pm_listPlugins', h);
+void UFO_pm_listPlugins(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
+
 // -----------------------------------------------------------------------------
 // TaskGraph API
 // -----------------------------------------------------------------------------

--- a/matlab/src/mexUfo_handle.c
+++ b/matlab/src/mexUfo_handle.c
@@ -3,10 +3,10 @@
  * One uint64 key  ↔  one GObject*  (+ type tag string)
  *
  *  – safe on 64-bit MATLAB, O(1) lookup
- *  – automatic final clean-up via mexAtExit
+ *  – automatic final clean-up via explicit init/shutdown
  */
 
-#include "ufo_mex_api.h"
+#include "mexUfo_handle.h"
 #include <mex.h>
 #include <glib.h>
 #include <stdint.h>
@@ -39,25 +39,16 @@ static void entry_free (gpointer data)
     g_free (e);
 }
 
-static void registry_ensure (void)
+static void registry_ensure(void)
 {
-    if (g_registry) return;
+    if (g_registry)
+        return;
 
-    g_mutex_init (&g_registry_mtx);
-
-    /* Direct hash/equal treat key as pointer-sized scalar – fine on 64-bit */
-    g_registry = g_hash_table_new_full (g_direct_hash,
-                                        g_direct_equal,
-                                        NULL,           /* key not separately allocated */
-                                        entry_free);
-
-    mexAtExit ([]() {                       /* lambda requires C11 / GCC ≥4.9;        */
-        if (g_registry) {                   /* if C99 only, write a static function */
-            g_hash_table_destroy (g_registry);
-            g_registry = NULL;
-            g_mutex_clear (&g_registry_mtx);
-        }
-    });
+    g_mutex_init(&g_registry_mtx);
+    g_registry = g_hash_table_new_full(g_direct_hash,
+                                       g_direct_equal,
+                                       NULL,
+                                       entry_free);
 }
 
 /* ------------------------------------------------------------------ */
@@ -161,3 +152,33 @@ UfoTaskGraph     *ufoHandle_getTaskGraph    (const mxArray *arr)
 
 UfoBaseScheduler *ufoHandle_getScheduler    (const mxArray *arr)
 { return UFO_BASE_SCHEDULER (lookup (arr, "scheduler")->obj); }
+
+UfoTask *ufoHandle_getTask(const mxArray *arr)
+{ return UFO_TASK (lookup (arr, "task")->obj); }
+
+UfoResources *ufoHandle_getResources(const mxArray *arr)
+{ return UFO_RESOURCES (lookup (arr, "resources")->obj); }
+
+/* Init/cleanup ---------------------------------------------------- */
+
+void mexUfo_handle_init(void)
+{
+    registry_ensure();
+}
+
+void mexUfo_handle_shutdown(void)
+{
+    if (!g_registry)
+        return;
+
+    g_hash_table_destroy(g_registry);
+    g_registry = NULL;
+    g_mutex_clear(&g_registry_mtx);
+    g_next_id = 1;
+}
+
+/* Compatibility wrapper used by older sources */
+mxArray *createUfoHandle(UFO_Handle handle, const char *className)
+{
+    return ufoHandle_create((gpointer)(uintptr_t)handle, className);
+}

--- a/matlab/src/ufo_mex.c
+++ b/matlab/src/ufo_mex.c
@@ -28,7 +28,7 @@ static mexFunctionPtr find_verb(const char *name) {
         {"Buffer_new",         UFO_buf_new},
         {"PluginManager_free", UFO_pm_delete},
         {"PluginManager_getTask", UFO_pm_getTask},
-        {"PluginManager_listPlugins", NULL}, // Not implemented, placeholder
+        {"PluginManager_listPlugins", UFO_pm_listPlugins},
         {"PluginManager_new",  UFO_pm_new},
         {"Scheduler_delete",   UFO_sched_delete},
         {"Scheduler_free",     UFO_sched_delete}, // alias

--- a/tests/+ufoTest/TestBuffer.m
+++ b/tests/+ufoTest/TestBuffer.m
@@ -1,0 +1,10 @@
+classdef TestBuffer < matlab.unittest.TestCase
+    %TESTBUFFER Unit tests for ufo.Buffer basic behaviour
+    methods(Test)
+        function newGetSizeFree(testCase)
+            %TODO: create buffer via ufo.Buffer and verify size is numeric
+            %After deleting the object, any method call should error with
+            %'ufo:Buffer:InvalidHandle'.
+        end
+    end
+end

--- a/tests/+ufoTest/TestPluginManager.m
+++ b/tests/+ufoTest/TestPluginManager.m
@@ -1,0 +1,10 @@
+classdef TestPluginManager < matlab.unittest.TestCase
+    %TESTPLUGINMANAGER Validate ufo.PluginManager behaviour
+    methods(Test)
+        function listPlugins(testCase)
+            pm = ufo.PluginManager(); %#ok<NASGU>
+            %TODO: fetch plugin list via listPlugins and ensure it is a
+            %non-empty cell array of character vectors
+        end
+    end
+end

--- a/tests/+ufoTest/TestReconstructionE2E.m
+++ b/tests/+ufoTest/TestReconstructionE2E.m
@@ -1,0 +1,14 @@
+classdef TestReconstructionE2E < matlab.unittest.TestCase
+    %TESTRECONSTRUCTIONE2E End-to-end regression tests for full pipeline
+    properties(Constant)
+        DataDir = fullfile(fileparts(mfilename('fullpath')), 'data');
+    end
+    methods(Test)
+        function parallelBeam(testCase)
+            %TODO: run reconstruction on parallel-beam sample and compare
+        end
+        function fanBeam(testCase)
+            %TODO: run reconstruction on fan-beam sample and compare
+        end
+    end
+end

--- a/tests/+ufoTest/TestSchedulerIntegration.m
+++ b/tests/+ufoTest/TestSchedulerIntegration.m
@@ -1,0 +1,9 @@
+classdef TestSchedulerIntegration < matlab.unittest.TestCase
+    %TESTSCHEDULERINTEGRATION Integration test running a minimal graph
+    methods(Test)
+        function readWritePipeline(testCase)
+            %TODO: Build a read->write pipeline using temp files
+            %Run via ufo.Scheduler and check that output file exists
+        end
+    end
+end

--- a/tests/+ufoTest/TestTaskGraph.m
+++ b/tests/+ufoTest/TestTaskGraph.m
@@ -1,0 +1,13 @@
+classdef TestTaskGraph < matlab.unittest.TestCase
+    %TESTTASKGRAPH Basic validation for ufo.TaskGraph
+    methods(Test)
+        function addNodeInvalid(testCase)
+            tg = ufo.TaskGraph(); %#ok<NASGU>
+            %TODO: calling addNode with wrong type should raise an error
+        end
+        function connectBadInput(testCase)
+            tg = ufo.TaskGraph();
+            %TODO: verify connect complains on invalid endpoints
+        end
+    end
+end

--- a/tests/mex_smoke.c
+++ b/tests/mex_smoke.c
@@ -1,0 +1,21 @@
+#include "mex.h"
+
+int main(void)
+{
+    mxArray *lhs[1];
+    mxArray *rhs1[1];
+    rhs1[0] = mxCreateString("Buffer_new");
+    if (mexCallMATLAB(1, lhs, 1, rhs1, "ufo_mex"))
+        return 1;
+
+    mxArray *rhs2[2];
+    rhs2[0] = mxCreateString("Buffer_free");
+    rhs2[1] = lhs[0];
+    if (mexCallMATLAB(0, NULL, 2, rhs2, "ufo_mex"))
+        return 2;
+
+    mxDestroyArray(rhs1[0]);
+    mxDestroyArray(rhs2[0]);
+    mxDestroyArray(lhs[0]);
+    return 0;
+}

--- a/tests/runAllTests.m
+++ b/tests/runAllTests.m
@@ -1,0 +1,4 @@
+import matlab.unittest.TestSuite;
+addpath(fullfile(fileparts(mfilename('fullpath')), '..'));  % add +ufo
+results = run(TestSuite.fromPackage('ufoTest','IncludeSubpackages',true));
+assertSuccess(results);


### PR DESCRIPTION
## Summary
- fix MATLAB CMake source path and exclude old dispatcher
- add mexUfo_handle API for handle management
- implement missing getters and init/shutdown helpers
- stub convertReportsToMx and listPlugins handler
- update dispatch table for new command

## Testing
- `which matlab` *(fails: command not found)*