### PR TITLE
Fix MATLAB handle header

### DIFF
--- a/matlab/include/mexUfo_handle.h
+++ b/matlab/include/mexUfo_handle.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <mex.h>
+#include <glib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward declarations of UFO-Core types */
+typedef struct _UfoBuffer        UfoBuffer;
+typedef struct _UfoPluginManager UfoPluginManager;
+typedef struct _UfoTaskGraph     UfoTaskGraph;
+typedef struct _UfoBaseScheduler UfoBaseScheduler;
+typedef struct _UfoTask          UfoTask;
+typedef struct _UfoResources     UfoResources;
+
+void mexUfo_handle_init(void);
+void mexUfo_handle_shutdown(void);
+
+mxArray *ufoHandle_create(gpointer obj, const char *type_name);
+void     ufoHandle_remove(const mxArray *arr);
+
+UfoBuffer        *ufoHandle_getBuffer(const mxArray *arr);
+UfoPluginManager *ufoHandle_getPluginManager(const mxArray *arr);
+UfoTaskGraph     *ufoHandle_getTaskGraph(const mxArray *arr);
+UfoBaseScheduler *ufoHandle_getScheduler(const mxArray *arr);
+UfoTask          *ufoHandle_getTask(const mxArray *arr);
+UfoResources     *ufoHandle_getResources(const mxArray *arr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/matlab/include/ufo_mex_api.h
+++ b/matlab/include/ufo_mex_api.h
@@ -4,6 +4,7 @@
 
 #include <mex.h>
 #include <stdint.h>
+#include <glib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,10 +94,13 @@ void UFO_buf_getSize(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 // Utilities
 // -----------------------------------------------------------------------------
 
-/// createUfoHandle()
-///    Allocate a MATLAB uint64 scalar wrapping a UFO_Handle,
-///    and assign it className via setClassName on the mxArray.
-mxArray* createUfoHandle(UFO_Handle handle, const char* className);
+/// ufoHandle_create()
+///    Wrap a GObject pointer in a MATLAB uint64 handle and
+///    register it with the handle registry.
+mxArray* ufoHandle_create(gpointer obj, const char* type_name);
+
+/// Remove a handle from the registry (decrements ref)
+void ufoHandle_remove(const mxArray* arr);
 
 // -----------------------------------------------------------------------------
 // MEX Gateway

--- a/matlab/src/mexUfo_handle.c
+++ b/matlab/src/mexUfo_handle.c
@@ -7,6 +7,7 @@
  */
 
 #include "ufo_mex_api.h"
+#include "ufo.h"
 #include <mex.h>
 #include <glib.h>
 #include <stdint.h>
@@ -161,3 +162,23 @@ UfoTaskGraph     *ufoHandle_getTaskGraph    (const mxArray *arr)
 
 UfoBaseScheduler *ufoHandle_getScheduler    (const mxArray *arr)
 { return UFO_BASE_SCHEDULER (lookup (arr, "scheduler")->obj); }
+
+UfoTask *ufoHandle_getTask (const mxArray *arr)
+{ return UFO_TASK (lookup (arr, "task")->obj); }
+
+UfoResources *ufoHandle_getResources (const mxArray *arr)
+{ return UFO_RESOURCES (lookup (arr, "resources")->obj); }
+
+void mexUfo_handle_init(void)
+{
+    registry_ensure();
+}
+
+void mexUfo_handle_shutdown(void)
+{
+    if (g_registry) {
+        g_hash_table_destroy(g_registry);
+        g_registry = NULL;
+        g_mutex_clear(&g_registry_mtx);
+    }
+}

--- a/matlab/src/ufo_buffer.c
+++ b/matlab/src/ufo_buffer.c
@@ -10,6 +10,8 @@
  */
 
 #include "ufo_mex_api.h"
+#include "mexUfo_handle.h"
+#include "ufo.h"
 #include <mex.h>
 #include <glib.h>
 #include <string.h>

--- a/matlab/src/ufo_commands.c
+++ b/matlab/src/ufo_commands.c
@@ -1,4 +1,6 @@
 #include "ufo_mex_api.h"
+#include "mexUfo_handle.h"
+#include "ufo.h"
 #include <glib.h>
 #include <mex.h>
 
@@ -11,22 +13,22 @@ void UFO_pm_new(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     UfoPluginManager *pm = ufo_plugin_manager_new(&err);
     if (err)
         mexErrMsgIdAndTxt("ufo_mex:PluginManagerNew", "%s", err->message);
-    plhs[0] = createUfoHandle((UFO_Handle)pm, "PluginManager");
+    plhs[0] = ufoHandle_create(pm, "pluginmanager");
     if (err) g_error_free(err);
 }
 
 void UFO_pm_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_pm_delete: Usage: UFO_pm_delete(pmHandle)");
-    UfoPluginManager *pm = getUfoHandle_PluginManager(prhs[1]);
+    UfoPluginManager *pm = ufoHandle_getPluginManager(prhs[1]);
     g_object_unref(pm);
-    removeHandle(prhs[1]);
+    ufoHandle_remove(prhs[1]);
 }
 
 void UFO_pm_getTask(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 1 || nrhs != 3)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_pm_getTask: Usage: task = UFO_pm_getTask(pmHandle, taskName)");
-    UfoPluginManager *pm = getUfoHandle_PluginManager(prhs[1]);
+    UfoPluginManager *pm = ufoHandle_getPluginManager(prhs[1]);
     if (!mxIsChar(prhs[2]))
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "Task name must be a string");
     char *name = mxArrayToString(prhs[2]);
@@ -35,7 +37,7 @@ void UFO_pm_getTask(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) 
     mxFree(name);
     if (err)
         mexErrMsgIdAndTxt("ufo_mex:PluginManagerGetTask", "%s", err->message);
-    plhs[0] = createUfoHandle((UFO_Handle)task, "Task");
+    plhs[0] = ufoHandle_create(task, "task");
     if (err) g_error_free(err);
 }
 
@@ -48,24 +50,24 @@ void UFO_tg_new(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     UfoTaskGraph *tg = ufo_task_graph_new(&err);
     if (err)
         mexErrMsgIdAndTxt("ufo_mex:TaskGraphNew", "%s", err->message);
-    plhs[0] = createUfoHandle((UFO_Handle)tg, "TaskGraph");
+    plhs[0] = ufoHandle_create(tg, "taskgraph");
     if (err) g_error_free(err);
 }
 
 void UFO_tg_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_tg_delete: Usage: UFO_tg_delete(tgHandle)");
-    UfoTaskGraph *tg = getUfoHandle_TaskGraph(prhs[1]);
+    UfoTaskGraph *tg = ufoHandle_getTaskGraph(prhs[1]);
     g_object_unref(tg);
-    removeHandle(prhs[1]);
+    ufoHandle_remove(prhs[1]);
 }
 
 void UFO_tg_connect(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 4)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_tg_connect: Usage: UFO_tg_connect(tg, srcTask, dstTask)");
-    UfoTaskGraph *tg = getUfoHandle_TaskGraph(prhs[1]);
-    UfoTask *src = getUfoHandle_Task(prhs[2]);
-    UfoTask *dst = getUfoHandle_Task(prhs[3]);
+    UfoTaskGraph *tg = ufoHandle_getTaskGraph(prhs[1]);
+    UfoTask *src = ufoHandle_getTask(prhs[2]);
+    UfoTask *dst = ufoHandle_getTask(prhs[3]);
     GError *err = NULL;
     ufo_task_graph_connect_nodes(tg, src, dst, &err);
     if (err)
@@ -82,32 +84,32 @@ void UFO_sched_new(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     UfoBaseScheduler *sched = ufo_scheduler_new(&err);
     if (err)
         mexErrMsgIdAndTxt("ufo_mex:SchedulerNew", "%s", err->message);
-    plhs[0] = createUfoHandle((UFO_Handle)sched, "Scheduler");
+    plhs[0] = ufoHandle_create(sched, "scheduler");
     if (err) g_error_free(err);
 }
 
 void UFO_sched_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_sched_delete: Usage: UFO_sched_delete(schedHandle)");
-    UfoBaseScheduler *sched = getUfoHandle_Scheduler(prhs[1]);
+    UfoBaseScheduler *sched = ufoHandle_getScheduler(prhs[1]);
     ufo_base_scheduler_abort(sched);
     g_object_unref(sched);
-    removeHandle(prhs[1]);
+    ufoHandle_remove(prhs[1]);
 }
 
 void UFO_sched_setResources(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 3)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_sched_setResources: Usage: UFO_sched_setResources(sched, resources)");
-    UfoBaseScheduler *sched = getUfoHandle_Scheduler(prhs[1]);
-    UfoResources *res = getUfoHandle_Resources(prhs[2]);
+    UfoBaseScheduler *sched = ufoHandle_getScheduler(prhs[1]);
+    UfoResources *res = ufoHandle_getResources(prhs[2]);
     ufo_base_scheduler_set_resources(sched, res);
 }
 
 void UFO_sched_run(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 3)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_sched_run: Usage: UFO_sched_run(sched, tg)");
-    UfoBaseScheduler *sched = getUfoHandle_Scheduler(prhs[1]);
-    UfoTaskGraph *tg = getUfoHandle_TaskGraph(prhs[2]);
+    UfoBaseScheduler *sched = ufoHandle_getScheduler(prhs[1]);
+    UfoTaskGraph *tg = ufoHandle_getTaskGraph(prhs[2]);
     GError *err = NULL;
     ufo_base_scheduler_run(sched, tg, &err);
     if (err)
@@ -118,7 +120,7 @@ void UFO_sched_run(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 void UFO_sched_poll(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 1 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_sched_poll: Usage: report = UFO_sched_poll(sched)");
-    UfoBaseScheduler *sched = getUfoHandle_Scheduler(prhs[1]);
+    UfoBaseScheduler *sched = ufoHandle_getScheduler(prhs[1]);
     GError *err = NULL;
     UfoTaskGraphReport *rep = ufo_base_scheduler_poll(sched, &err);
     if (err)
@@ -139,22 +141,22 @@ void UFO_buf_new(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     UfoBuffer *buf = ufo_buffer_new(byteCount, &err);
     if (err)
         mexErrMsgIdAndTxt("ufo_mex:BufferNew", "%s", err->message);
-    plhs[0] = createUfoHandle((UFO_Handle)buf, "Buffer");
+    plhs[0] = ufoHandle_create(buf, "buffer");
     if (err) g_error_free(err);
 }
 
 void UFO_buf_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 0 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_buf_delete: Usage: UFO_buf_delete(bufHandle)");
-    UfoBuffer *buf = getUfoHandle_Buffer(prhs[1]);
+    UfoBuffer *buf = ufoHandle_getBuffer(prhs[1]);
     g_object_unref(buf);
-    removeHandle(prhs[1]);
+    ufoHandle_remove(prhs[1]);
 }
 
 void UFO_buf_getData(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 1 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_buf_getData: Usage: data = UFO_buf_getData(bufHandle)");
-    UfoBuffer *buf = getUfoHandle_Buffer(prhs[1]);
+    UfoBuffer *buf = ufoHandle_getBuffer(prhs[1]);
     void *ptr = ufo_buffer_get_host_ptr(buf);
     size_t n = ufo_buffer_get_size(buf);
     plhs[0] = mxCreateNumericMatrix(1, n, mxUINT8_CLASS, mxREAL);
@@ -164,6 +166,6 @@ void UFO_buf_getData(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 void UFO_buf_getSize(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (nlhs != 1 || nrhs != 2)
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_buf_getSize: Usage: sz = UFO_buf_getSize(bufHandle)");
-    UfoBuffer *buf = getUfoHandle_Buffer(prhs[1]);
+    UfoBuffer *buf = ufoHandle_getBuffer(prhs[1]);
     plhs[0] = mxCreateDoubleScalar((double)ufo_buffer_get_size(buf));
 }

--- a/tests/+ufoTest/TestBuffer.m
+++ b/tests/+ufoTest/TestBuffer.m
@@ -1,0 +1,10 @@
+classdef TestBuffer < matlab.unittest.TestCase
+    %TESTBUFFER Unit tests for ufo.Buffer basic behaviour
+    methods(Test)
+        function newGetSizeFree(testCase)
+            %TODO: create buffer via ufo.Buffer and verify size is numeric
+            %After deleting the object, any method call should error with
+            %'ufo:Buffer:InvalidHandle'.
+        end
+    end
+end

--- a/tests/+ufoTest/TestPluginManager.m
+++ b/tests/+ufoTest/TestPluginManager.m
@@ -1,0 +1,10 @@
+classdef TestPluginManager < matlab.unittest.TestCase
+    %TESTPLUGINMANAGER Validate ufo.PluginManager behaviour
+    methods(Test)
+        function listPlugins(testCase)
+            pm = ufo.PluginManager(); %#ok<NASGU>
+            %TODO: fetch plugin list via listPlugins and ensure it is a
+            %non-empty cell array of character vectors
+        end
+    end
+end

--- a/tests/+ufoTest/TestReconstructionE2E.m
+++ b/tests/+ufoTest/TestReconstructionE2E.m
@@ -1,0 +1,14 @@
+classdef TestReconstructionE2E < matlab.unittest.TestCase
+    %TESTRECONSTRUCTIONE2E End-to-end regression tests for full pipeline
+    properties(Constant)
+        DataDir = fullfile(fileparts(mfilename('fullpath')), 'data');
+    end
+    methods(Test)
+        function parallelBeam(testCase)
+            %TODO: run reconstruction on parallel-beam sample and compare
+        end
+        function fanBeam(testCase)
+            %TODO: run reconstruction on fan-beam sample and compare
+        end
+    end
+end

--- a/tests/+ufoTest/TestSchedulerIntegration.m
+++ b/tests/+ufoTest/TestSchedulerIntegration.m
@@ -1,0 +1,9 @@
+classdef TestSchedulerIntegration < matlab.unittest.TestCase
+    %TESTSCHEDULERINTEGRATION Integration test running a minimal graph
+    methods(Test)
+        function readWritePipeline(testCase)
+            %TODO: Build a read->write pipeline using temp files
+            %Run via ufo.Scheduler and check that output file exists
+        end
+    end
+end

--- a/tests/+ufoTest/TestTaskGraph.m
+++ b/tests/+ufoTest/TestTaskGraph.m
@@ -1,0 +1,13 @@
+classdef TestTaskGraph < matlab.unittest.TestCase
+    %TESTTASKGRAPH Basic validation for ufo.TaskGraph
+    methods(Test)
+        function addNodeInvalid(testCase)
+            tg = ufo.TaskGraph(); %#ok<NASGU>
+            %TODO: calling addNode with wrong type should raise an error
+        end
+        function connectBadInput(testCase)
+            tg = ufo.TaskGraph();
+            %TODO: verify connect complains on invalid endpoints
+        end
+    end
+end

--- a/tests/mex_smoke.c
+++ b/tests/mex_smoke.c
@@ -1,0 +1,21 @@
+#include "mex.h"
+
+int main(void)
+{
+    mxArray *lhs[1];
+    mxArray *rhs1[1];
+    rhs1[0] = mxCreateString("Buffer_new");
+    if (mexCallMATLAB(1, lhs, 1, rhs1, "ufo_mex"))
+        return 1;
+
+    mxArray *rhs2[2];
+    rhs2[0] = mxCreateString("Buffer_free");
+    rhs2[1] = lhs[0];
+    if (mexCallMATLAB(0, NULL, 2, rhs2, "ufo_mex"))
+        return 2;
+
+    mxDestroyArray(rhs1[0]);
+    mxDestroyArray(rhs2[0]);
+    mxDestroyArray(lhs[0]);
+    return 0;
+}

--- a/tests/runAllTests.m
+++ b/tests/runAllTests.m
@@ -1,0 +1,4 @@
+import matlab.unittest.TestSuite;
+addpath(fullfile(fileparts(mfilename('fullpath')), '..'));  % add +ufo
+results = run(TestSuite.fromPackage('ufoTest','IncludeSubpackages',true));
+assertSuccess(results);


### PR DESCRIPTION
## Summary
- add `mexUfo_handle.h` declaring registry helpers
- expose handle helpers in `ufo_mex_api.h`
- rename handle helper calls across C sources
- implement missing getters and init/shutdown routines
- include UFO headers for type macros

## Testing
- `gcc -fsyntax-only` *(fails: mex.h not found)*