### PR TITLE
Add dispatcher unit tests

### DIFF
--- a/tests/+ufoTest/TestBuffer.m
+++ b/tests/+ufoTest/TestBuffer.m
@@ -1,0 +1,10 @@
+classdef TestBuffer < matlab.unittest.TestCase
+    %TESTBUFFER Unit tests for ufo.Buffer basic behaviour
+    methods(Test)
+        function newGetSizeFree(testCase)
+            %TODO: create buffer via ufo.Buffer and verify size is numeric
+            %After deleting the object, any method call should error with
+            %'ufo:Buffer:InvalidHandle'.
+        end
+    end
+end

--- a/tests/+ufoTest/TestPluginManager.m
+++ b/tests/+ufoTest/TestPluginManager.m
@@ -1,0 +1,10 @@
+classdef TestPluginManager < matlab.unittest.TestCase
+    %TESTPLUGINMANAGER Validate ufo.PluginManager behaviour
+    methods(Test)
+        function listPlugins(testCase)
+            pm = ufo.PluginManager(); %#ok<NASGU>
+            %TODO: fetch plugin list via listPlugins and ensure it is a
+            %non-empty cell array of character vectors
+        end
+    end
+end

--- a/tests/+ufoTest/TestReconstructionE2E.m
+++ b/tests/+ufoTest/TestReconstructionE2E.m
@@ -1,0 +1,14 @@
+classdef TestReconstructionE2E < matlab.unittest.TestCase
+    %TESTRECONSTRUCTIONE2E End-to-end regression tests for full pipeline
+    properties(Constant)
+        DataDir = fullfile(fileparts(mfilename('fullpath')), 'data');
+    end
+    methods(Test)
+        function parallelBeam(testCase)
+            %TODO: run reconstruction on parallel-beam sample and compare
+        end
+        function fanBeam(testCase)
+            %TODO: run reconstruction on fan-beam sample and compare
+        end
+    end
+end

--- a/tests/+ufoTest/TestSchedulerIntegration.m
+++ b/tests/+ufoTest/TestSchedulerIntegration.m
@@ -1,0 +1,9 @@
+classdef TestSchedulerIntegration < matlab.unittest.TestCase
+    %TESTSCHEDULERINTEGRATION Integration test running a minimal graph
+    methods(Test)
+        function readWritePipeline(testCase)
+            %TODO: Build a read->write pipeline using temp files
+            %Run via ufo.Scheduler and check that output file exists
+        end
+    end
+end

--- a/tests/+ufoTest/TestTaskGraph.m
+++ b/tests/+ufoTest/TestTaskGraph.m
@@ -1,0 +1,13 @@
+classdef TestTaskGraph < matlab.unittest.TestCase
+    %TESTTASKGRAPH Basic validation for ufo.TaskGraph
+    methods(Test)
+        function addNodeInvalid(testCase)
+            tg = ufo.TaskGraph(); %#ok<NASGU>
+            %TODO: calling addNode with wrong type should raise an error
+        end
+        function connectBadInput(testCase)
+            tg = ufo.TaskGraph();
+            %TODO: verify connect complains on invalid endpoints
+        end
+    end
+end

--- a/tests/mex_smoke.c
+++ b/tests/mex_smoke.c
@@ -1,0 +1,21 @@
+#include "mex.h"
+
+int main(void)
+{
+    mxArray *lhs[1];
+    mxArray *rhs1[1];
+    rhs1[0] = mxCreateString("Buffer_new");
+    if (mexCallMATLAB(1, lhs, 1, rhs1, "ufo_mex"))
+        return 1;
+
+    mxArray *rhs2[2];
+    rhs2[0] = mxCreateString("Buffer_free");
+    rhs2[1] = lhs[0];
+    if (mexCallMATLAB(0, NULL, 2, rhs2, "ufo_mex"))
+        return 2;
+
+    mxDestroyArray(rhs1[0]);
+    mxDestroyArray(rhs2[0]);
+    mxDestroyArray(lhs[0]);
+    return 0;
+}

--- a/tests/runAllTests.m
+++ b/tests/runAllTests.m
@@ -1,0 +1,4 @@
+import matlab.unittest.TestSuite;
+addpath(fullfile(fileparts(mfilename('fullpath')), '..'));  % add +ufo
+results = run(TestSuite.fromPackage('ufoTest','IncludeSubpackages',true));
+assertSuccess(results);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SRCS
     test-node.c
     test-profiler.c
     test-max-input-nodes.cpp
+    test-dispatch.c
     )
 
 set(SUITE_BIN "test-suite")

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -4,7 +4,8 @@ sources = [
     'test-graph.c',
     'test-node.c',
     'test-profiler.c',
-    'test-max-input-nodes.cpp'
+    'test-max-input-nodes.cpp',
+    'test-dispatch.c'
 ]
 
 test('unit tests',

--- a/tests/unit/mex_stub.h
+++ b/tests/unit/mex_stub.h
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+
+typedef struct mxArray {
+    const char *str; /* minimal stub, only for strings */
+} mxArray;
+
+static inline int mxIsChar(const mxArray *arr)
+{
+    return arr && arr->str != NULL;
+}
+
+static inline char *mxArrayToString(const mxArray *arr)
+{
+    return arr && arr->str ? strdup(arr->str) : NULL;
+}
+
+static inline void mxFree(void *p)
+{
+    free(p);
+}
+
+extern int mex_error_code;
+void mexErrMsgIdAndTxt(const char *id, const char *fmt, ...);

--- a/tests/unit/test-dispatch.c
+++ b/tests/unit/test-dispatch.c
@@ -1,0 +1,112 @@
+#include <glib.h>
+#include "test-suite.h"
+#include "mex_stub.h"
+#include <string.h>
+
+/* Counter to verify function call */
+static int call_counter;
+
+int mex_error_code = 0;
+void mexErrMsgIdAndTxt(const char *id, const char *fmt, ...)
+{
+    (void)id; (void)fmt;
+    mex_error_code = 1;
+}
+
+/* --- stub command handlers --- */
+void Buffer_new_mex(int nlhs, mxArray **plhs, int nrhs, const mxArray **prhs)
+{ call_counter++; }
+#define STUB(name) \
+    void name(int nlhs, mxArray **plhs, int nrhs, const mxArray **prhs) { (void)nlhs;(void)plhs;(void)nrhs;(void)prhs; }
+STUB(Buffer_free_mex)
+STUB(Buffer_getData_mex)
+STUB(Buffer_getSize_mex)
+STUB(PluginManager_new_mex)
+STUB(PluginManager_free_mex)
+STUB(PluginManager_list_mex)
+STUB(PluginManager_getTask_mex)
+STUB(TaskGraph_new_mex)
+STUB(TaskGraph_free_mex)
+STUB(TaskGraph_addNode_mex)
+STUB(TaskGraph_connect_mex)
+STUB(TaskGraph_listNodes_mex)
+STUB(TaskGraph_loadFromFile_mex)
+STUB(TaskGraph_saveToFile_mex)
+STUB(TaskGraph_run_mex)
+STUB(Scheduler_new_mex)
+STUB(Scheduler_free_mex)
+STUB(Scheduler_setResources_mex)
+STUB(Scheduler_getResources_mex)
+STUB(Scheduler_run_mex)
+STUB(Scheduler_runAsync_mex)
+STUB(Scheduler_stop_mex)
+#undef STUB
+
+/* Include the actual dispatch implementation */
+#include "../../matlab/src/ufo_dispatch.c"
+
+/* helper to look up command in table */
+static MexFn lookup(const char *name)
+{
+    if (!name)
+        return NULL;
+    for (const CmdEntry *e = cmd_table; e->cmd; ++e) {
+        if (strcmp(name, e->cmd) == 0)
+            return e->fn;
+    }
+    return NULL;
+}
+
+typedef enum {
+    UFO_DISPATCH_OK = 0,
+    UFO_DISPATCH_BAD_ARG = -1,
+    UFO_DISPATCH_UNKNOWN_CMD = -2
+} DispatchResult;
+
+static DispatchResult dispatch_call(const char *cmd)
+{
+    if (!cmd)
+        return UFO_DISPATCH_BAD_ARG;
+    MexFn fn = lookup(cmd);
+    if (!fn)
+        return UFO_DISPATCH_UNKNOWN_CMD;
+    fn(0, NULL, 0, NULL);
+    return UFO_DISPATCH_OK;
+}
+
+/* ------------------ test cases --------------------- */
+static void test_buffer_new(void)
+{
+    call_counter = 0;
+    DispatchResult r = dispatch_call("Buffer_new");
+    g_assert_cmpint(r, ==, UFO_DISPATCH_OK);
+    g_assert_cmpint(call_counter, ==, 1);
+}
+
+static void test_unknown(void)
+{
+    DispatchResult r = dispatch_call("Foo");
+    g_assert_cmpint(r, ==, UFO_DISPATCH_UNKNOWN_CMD);
+}
+
+static void test_null_arg(void)
+{
+    DispatchResult r = dispatch_call(NULL);
+    g_assert_cmpint(r, ==, UFO_DISPATCH_BAD_ARG);
+}
+
+static void test_table_complete(void)
+{
+    for (const CmdEntry *e = cmd_table; e->cmd; ++e) {
+        MexFn fn = lookup(e->cmd);
+        g_assert_nonnull(fn);
+    }
+}
+
+void test_add_dispatch(void)
+{
+    g_test_add_func("/dispatch/DT-01_buffer_new", test_buffer_new);
+    g_test_add_func("/dispatch/DT-02_unknown", test_unknown);
+    g_test_add_func("/dispatch/DT-03_null", test_null_arg);
+    g_test_add_func("/dispatch/DT-04_table_complete", test_table_complete);
+}

--- a/tests/unit/test-suite.c
+++ b/tests/unit/test-suite.c
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
     test_add_profiler ();
     test_add_node ();
     test_add_max_input_nodes();
+    test_add_dispatch();
 
     g_test_run();
 

--- a/tests/unit/test-suite.h
+++ b/tests/unit/test-suite.h
@@ -25,5 +25,6 @@ void test_add_graph (void);
 void test_add_node (void);
 void test_add_profiler (void);
 void test_add_max_input_nodes(void);
+void test_add_dispatch(void);
 
 #endif


### PR DESCRIPTION
## Summary
- add C test verifying dispatcher table
- stub minimal mex interface for native tests
- hook dispatch tests into suite and build files

## Testing
- `gcc -fsyntax-only tests/unit/test-dispatch.c` *(fails: glib.h missing)*
