### PR TITLE
Fix Buffer constructor invocation

### DIFF
--- a/tests/mex_smoke.c
+++ b/tests/mex_smoke.c
@@ -3,9 +3,10 @@
 int main(void)
 {
     mxArray *lhs[1];
-    mxArray *rhs1[1];
+    mxArray *rhs1[2];
     rhs1[0] = mxCreateString("Buffer_new");
-    if (mexCallMATLAB(1, lhs, 1, rhs1, "ufo_mex"))
+    rhs1[1] = mxCreateDoubleScalar(1);
+    if (mexCallMATLAB(1, lhs, 2, rhs1, "ufo_mex"))
         return 1;
 
     mxArray *rhs2[2];
@@ -15,6 +16,7 @@ int main(void)
         return 2;
 
     mxDestroyArray(rhs1[0]);
+    mxDestroyArray(rhs1[1]);
     mxDestroyArray(rhs2[0]);
     mxDestroyArray(lhs[0]);
     return 0;

--- a/tests/unit/test-dispatch.c
+++ b/tests/unit/test-dispatch.c
@@ -70,7 +70,13 @@ static DispatchResult dispatch_call(const char *cmd)
     MexFn fn = lookup(cmd);
     if (!fn)
         return UFO_DISPATCH_UNKNOWN_CMD;
-    fn(0, NULL, 0, NULL);
+
+    /* Simulate mexCallMATLAB(cmd, nBytes) */
+    mxArray cmdArr = { cmd };
+    mxArray argArr = { NULL };
+    const mxArray *rhs[2] = { &cmdArr, &argArr };
+
+    fn(0, NULL, 2, rhs);
     return UFO_DISPATCH_OK;
 }
 


### PR DESCRIPTION
## Summary
- ensure Buffer allocates with a size
- pass size to Buffer_new in mex smoke test
- simulate argument in dispatch unit test

## Testing
- `ninja -v` *(fails: loading 'build.ninja' no such file)*
- `make test` *(fails: No rule to make target 'test')*