### PR TITLE
Add OpenCL fallback test scaffolding

### DIFF
--- a/tests/+ufoTest/TestBuffer.m
+++ b/tests/+ufoTest/TestBuffer.m
@@ -1,0 +1,10 @@
+classdef TestBuffer < matlab.unittest.TestCase
+    %TESTBUFFER Unit tests for ufo.Buffer basic behaviour
+    methods(Test)
+        function newGetSizeFree(testCase)
+            %TODO: create buffer via ufo.Buffer and verify size is numeric
+            %After deleting the object, any method call should error with
+            %'ufo:Buffer:InvalidHandle'.
+        end
+    end
+end

--- a/tests/+ufoTest/TestOpenCLFallback.m
+++ b/tests/+ufoTest/TestOpenCLFallback.m
@@ -1,0 +1,15 @@
+classdef TestOpenCLFallback < matlab.unittest.TestCase
+    %TESTOPENCLFALLBACK Validate OpenCL CPU fallback logic
+    methods(Test)
+        function envCpuFallback(testCase)
+            % TODO: setenv('UFO_DEVICE_TYPE','CPU');
+            % Build GPU filter graph and run via ufo.Scheduler
+            % Verify execution succeeds on CPU
+        end
+        function malformedKernel(testCase)
+            % TODO: load a malformed CL kernel via ufo.Resources
+            % Expect error id 'ufo:Resources:LoadProgram'
+        end
+    end
+end
+

--- a/tests/+ufoTest/TestPluginManager.m
+++ b/tests/+ufoTest/TestPluginManager.m
@@ -1,0 +1,10 @@
+classdef TestPluginManager < matlab.unittest.TestCase
+    %TESTPLUGINMANAGER Validate ufo.PluginManager behaviour
+    methods(Test)
+        function listPlugins(testCase)
+            pm = ufo.PluginManager(); %#ok<NASGU>
+            %TODO: fetch plugin list via listPlugins and ensure it is a
+            %non-empty cell array of character vectors
+        end
+    end
+end

--- a/tests/+ufoTest/TestReconstructionE2E.m
+++ b/tests/+ufoTest/TestReconstructionE2E.m
@@ -1,0 +1,14 @@
+classdef TestReconstructionE2E < matlab.unittest.TestCase
+    %TESTRECONSTRUCTIONE2E End-to-end regression tests for full pipeline
+    properties(Constant)
+        DataDir = fullfile(fileparts(mfilename('fullpath')), 'data');
+    end
+    methods(Test)
+        function parallelBeam(testCase)
+            %TODO: run reconstruction on parallel-beam sample and compare
+        end
+        function fanBeam(testCase)
+            %TODO: run reconstruction on fan-beam sample and compare
+        end
+    end
+end

--- a/tests/+ufoTest/TestSchedulerIntegration.m
+++ b/tests/+ufoTest/TestSchedulerIntegration.m
@@ -1,0 +1,9 @@
+classdef TestSchedulerIntegration < matlab.unittest.TestCase
+    %TESTSCHEDULERINTEGRATION Integration test running a minimal graph
+    methods(Test)
+        function readWritePipeline(testCase)
+            %TODO: Build a read->write pipeline using temp files
+            %Run via ufo.Scheduler and check that output file exists
+        end
+    end
+end

--- a/tests/+ufoTest/TestTaskGraph.m
+++ b/tests/+ufoTest/TestTaskGraph.m
@@ -1,0 +1,13 @@
+classdef TestTaskGraph < matlab.unittest.TestCase
+    %TESTTASKGRAPH Basic validation for ufo.TaskGraph
+    methods(Test)
+        function addNodeInvalid(testCase)
+            tg = ufo.TaskGraph(); %#ok<NASGU>
+            %TODO: calling addNode with wrong type should raise an error
+        end
+        function connectBadInput(testCase)
+            tg = ufo.TaskGraph();
+            %TODO: verify connect complains on invalid endpoints
+        end
+    end
+end

--- a/tests/mex_smoke.c
+++ b/tests/mex_smoke.c
@@ -1,0 +1,21 @@
+#include "mex.h"
+
+int main(void)
+{
+    mxArray *lhs[1];
+    mxArray *rhs1[1];
+    rhs1[0] = mxCreateString("Buffer_new");
+    if (mexCallMATLAB(1, lhs, 1, rhs1, "ufo_mex"))
+        return 1;
+
+    mxArray *rhs2[2];
+    rhs2[0] = mxCreateString("Buffer_free");
+    rhs2[1] = lhs[0];
+    if (mexCallMATLAB(0, NULL, 2, rhs2, "ufo_mex"))
+        return 2;
+
+    mxDestroyArray(rhs1[0]);
+    mxDestroyArray(rhs2[0]);
+    mxDestroyArray(lhs[0]);
+    return 0;
+}

--- a/tests/runAllTests.m
+++ b/tests/runAllTests.m
@@ -1,0 +1,4 @@
+import matlab.unittest.TestSuite;
+addpath(fullfile(fileparts(mfilename('fullpath')), '..'));  % add +ufo
+results = run(TestSuite.fromPackage('ufoTest','IncludeSubpackages',true));
+assertSuccess(results);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SRCS
     test-node.c
     test-profiler.c
     test-max-input-nodes.cpp
+    test-opencl.c
     )
 
 set(SUITE_BIN "test-suite")

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -4,7 +4,8 @@ sources = [
     'test-graph.c',
     'test-node.c',
     'test-profiler.c',
-    'test-max-input-nodes.cpp'
+    'test-max-input-nodes.cpp',
+    'test-opencl.c'
 ]
 
 test('unit tests',

--- a/tests/unit/test-opencl.c
+++ b/tests/unit/test-opencl.c
@@ -1,0 +1,23 @@
+#include <glib.h>
+#include <ufo/ufo.h>
+#include "test-suite.h"
+
+static void test_cpu_env_fallback(void)
+{
+    // TODO: set environment variable UFO_DEVICE_TYPE=CPU
+    // build a simple graph with a GPU-only filter and run
+    // verify scheduler completes successfully on CPU
+}
+
+static void test_gpu_unavailable(void)
+{
+    // TODO: simulate unavailable GPU devices and run scheduler
+    // expect fallback to CPU and warning logged
+}
+
+void test_add_opencl_fallback(void)
+{
+    g_test_add_func("/opencl/cpu_env", test_cpu_env_fallback);
+    g_test_add_func("/opencl/gpu_unavailable", test_gpu_unavailable);
+}
+

--- a/tests/unit/test-suite.c
+++ b/tests/unit/test-suite.c
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
     test_add_profiler ();
     test_add_node ();
     test_add_max_input_nodes();
+    test_add_opencl_fallback();
 
     g_test_run();
 

--- a/tests/unit/test-suite.h
+++ b/tests/unit/test-suite.h
@@ -25,5 +25,6 @@ void test_add_graph (void);
 void test_add_node (void);
 void test_add_profiler (void);
 void test_add_max_input_nodes(void);
+void test_add_opencl_fallback(void);
 
 #endif


### PR DESCRIPTION
## Summary
- create `TestOpenCLFallback` MATLAB test skeleton
- outline native fallback tests in `test-opencl.c`
- register new tests in the unit test suite

## Testing
- `gcc -fsyntax-only tests/unit/test-opencl.c` *(fails: glib.h missing)*
- `which matlab` *(not found)*