### PR TITLE
Update cmake policies for 3.5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
-if (POLICY CMP0053)
-cmake_policy(SET CMP0053 OLD)
-endif ()
-
-if (POLICY CMP0054)
-cmake_policy(SET CMP0054 OLD)
-endif ()
-
 project(ufo)
 
 set(TARNAME "libufo")


### PR DESCRIPTION
## Summary
- drop CMP0053 and CMP0054 settings in root `CMakeLists.txt`
- ensure cmake version requirement is 3.5 across build files

## Testing
- `cmake -B build -S .` *(fails: Could NOT find OpenCL)*