### PR TITLE
Add MATLAB handle registry API header and init

### DIFF
--- a/matlab/include/mexUfo_handle.h
+++ b/matlab/include/mexUfo_handle.h
@@ -28,6 +28,8 @@ UfoBuffer        *ufoHandle_getBuffer(const mxArray *arr);
 UfoPluginManager *ufoHandle_getPluginManager(const mxArray *arr);
 UfoTaskGraph     *ufoHandle_getTaskGraph(const mxArray *arr);
 UfoBaseScheduler *ufoHandle_getScheduler(const mxArray *arr);
+UfoTask          *ufoHandle_getTask(const mxArray *arr);
+UfoResources     *ufoHandle_getResources(const mxArray *arr);
 #ifdef __cplusplus
 }
 #endif

--- a/matlab/src/mexUfo_handle.c
+++ b/matlab/src/mexUfo_handle.c
@@ -57,22 +57,6 @@ static void registry_ensure(void)
 /* Public API                                                         */
 /* ------------------------------------------------------------------ */
 
-void
-mexUfo_handle_init(void)
-{
-    registry_ensure();
-}
-
-void
-mexUfo_handle_shutdown(void)
-{
-    if (g_registry) {
-        g_hash_table_destroy(g_registry);
-        g_registry = NULL;
-        g_mutex_clear(&g_registry_mtx);
-        g_next_id = 1;
-    }
-}
 
 UFO_Handle
 ufo_handle_alloc(gpointer obj, const char *type_name)
@@ -216,9 +200,16 @@ UfoResources *ufoHandle_getResources(const mxArray *arr)
 
 /* Init/cleanup ---------------------------------------------------- */
 
+void mexUfo_handle_shutdown(void);
+
 void mexUfo_handle_init(void)
 {
+    static gboolean at_exit_registered = FALSE;
     registry_ensure();
+    if (!at_exit_registered) {
+        mexAtExit(mexUfo_handle_shutdown);
+        at_exit_registered = TRUE;
+    }
 }
 
 void mexUfo_handle_shutdown(void)
@@ -228,4 +219,5 @@ void mexUfo_handle_shutdown(void)
     g_hash_table_destroy(g_registry);
     g_registry = NULL;
     g_mutex_clear(&g_registry_mtx);
+    g_next_id = 1;
 }

--- a/matlab/src/ufo_mex.c
+++ b/matlab/src/ufo_mex.c
@@ -13,9 +13,6 @@ typedef struct {
 
 // --- Static helpers ---
 
-static void on_exit(void) {
-    mexUfo_handle_shutdown();
-}
 
 // Returns pointer to function for verb, or NULL if not found (binary search)
 static mexFunctionPtr find_verb(const char *name) {
@@ -72,7 +69,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
     if (!initialised) {
         mexLock();
         mexUfo_handle_init();
-        mexAtExit(on_exit);
         initialised = true;
     }
 


### PR DESCRIPTION
## Summary
- extend mexUfo_handle.h with additional typed getters
- register mexUfo_handle_shutdown via mexAtExit on first init
- remove duplicate init/shutdown code
- simplify ufo_mex.c initialisation

## Testing
- `meson test` *(fails: command not found)*