### PR TITLE
Add helper for wrapping existing handles

### DIFF
--- a/matlab/include/mexUfo_handle.h
+++ b/matlab/include/mexUfo_handle.h
@@ -23,6 +23,7 @@ extern gboolean ufo_handle_test_force_alloc_fail;
 
 /* MATLAB convenience wrappers */
 mxArray *ufoHandle_create(gpointer obj, const char *type_name);
+mxArray *ufoHandle_wrap(UFO_Handle id, const char *class_name);
 void     ufoHandle_remove(const mxArray *arr);
 UfoBuffer        *ufoHandle_getBuffer(const mxArray *arr);
 UfoPluginManager *ufoHandle_getPluginManager(const mxArray *arr);

--- a/matlab/src/mexUfo_handle.c
+++ b/matlab/src/mexUfo_handle.c
@@ -134,6 +134,23 @@ mxArray *ufoHandle_create (gpointer obj, const char *type_name)
     return arr;
 }
 
+/* Wrap an existing uint64 handle into a MATLAB mxArray and tag it with a
+   MATLAB class name.  This does not allocate or reference a GObject; it only
+   packages the handle value for return to the caller. */
+mxArray *ufoHandle_wrap(UFO_Handle id, const char *class_name)
+{
+    mxArray *arr = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
+    if (!arr)
+        mexErrMsgIdAndTxt("ufo_mex:AllocFailed",
+                          "Failed to allocate MATLAB handle.");
+
+    *(uint64_t *) mxGetData(arr) = id;
+    if (class_name && class_name[0] != '\0')
+        mxSetClassName(arr, class_name);
+
+    return arr;
+}
+
 /* Remove & unref */
 void ufoHandle_remove (const mxArray *arr)
 {


### PR DESCRIPTION
## Summary
- extend mexUfo_handle with a helper to wrap existing handles
- export the helper in the public header

## Testing
- `meson` not available, so unit tests were not run