### PR TITLE
Add Task and Resources bindings

### DIFF
--- a/matlab/include/mexUfo_handle.h
+++ b/matlab/include/mexUfo_handle.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <mex.h>
+#include <glib-object.h>
+#include <ufo/ufo.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mexUfo_handle_init(void);
+void mexUfo_handle_shutdown(void);
+
+mxArray *ufoHandle_create(gpointer obj, const char *type_name);
+void ufoHandle_remove(const mxArray *arr);
+
+UfoBuffer        *ufoHandle_getBuffer(const mxArray *arr);
+UfoPluginManager *ufoHandle_getPluginManager(const mxArray *arr);
+UfoTaskGraph     *ufoHandle_getTaskGraph(const mxArray *arr);
+UfoBaseScheduler *ufoHandle_getScheduler(const mxArray *arr);
+UfoTask          *ufoHandle_getTask(const mxArray *arr);
+UfoResources     *ufoHandle_getResources(const mxArray *arr);
+
+/* Compatibility wrappers for older names */
+static inline mxArray *createUfoHandle(UFO_Handle h, const char *type_name)
+{ return ufoHandle_create((gpointer) h, type_name); }
+static inline void removeHandle(const mxArray *arr)
+{ ufoHandle_remove(arr); }
+static inline UfoBuffer *getUfoHandle_Buffer(const mxArray *arr)
+{ return ufoHandle_getBuffer(arr); }
+static inline UfoPluginManager *getUfoHandle_PluginManager(const mxArray *arr)
+{ return ufoHandle_getPluginManager(arr); }
+static inline UfoTaskGraph *getUfoHandle_TaskGraph(const mxArray *arr)
+{ return ufoHandle_getTaskGraph(arr); }
+static inline UfoBaseScheduler *getUfoHandle_Scheduler(const mxArray *arr)
+{ return ufoHandle_getScheduler(arr); }
+static inline UfoTask *getUfoHandle_Task(const mxArray *arr)
+{ return ufoHandle_getTask(arr); }
+static inline UfoResources *getUfoHandle_Resources(const mxArray *arr)
+{ return ufoHandle_getResources(arr); }
+
+#ifdef __cplusplus
+}
+#endif

--- a/matlab/include/ufo_mex_api.h
+++ b/matlab/include/ufo_mex_api.h
@@ -90,6 +90,14 @@ void UFO_buf_getData(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 void UFO_buf_getSize(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
 
 // -----------------------------------------------------------------------------
+// Task & Resources API
+// -----------------------------------------------------------------------------
+
+void UFO_task_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
+void UFO_res_new(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
+void UFO_res_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]);
+
+// -----------------------------------------------------------------------------
 // Utilities
 // -----------------------------------------------------------------------------
 

--- a/matlab/src/mexUfo_handle.c
+++ b/matlab/src/mexUfo_handle.c
@@ -7,9 +7,12 @@
  */
 
 #include "ufo_mex_api.h"
+#include "mexUfo_handle.h"
 #include <mex.h>
 #include <glib.h>
 #include <stdint.h>
+#include <inttypes.h>
+#include <ufo/ufo.h>
 
 /* ------------------------------------------------------------------ */
 /* Registry structures                                                */
@@ -161,3 +164,23 @@ UfoTaskGraph     *ufoHandle_getTaskGraph    (const mxArray *arr)
 
 UfoBaseScheduler *ufoHandle_getScheduler    (const mxArray *arr)
 { return UFO_BASE_SCHEDULER (lookup (arr, "scheduler")->obj); }
+
+UfoTask          *ufoHandle_getTask         (const mxArray *arr)
+{ return UFO_TASK (lookup (arr, "task")->obj); }
+
+UfoResources     *ufoHandle_getResources    (const mxArray *arr)
+{ return UFO_RESOURCES (lookup (arr, "resources")->obj); }
+
+void mexUfo_handle_init(void)
+{
+    registry_ensure();
+}
+
+void mexUfo_handle_shutdown(void)
+{
+    if (g_registry) {
+        g_hash_table_destroy(g_registry);
+        g_registry = NULL;
+        g_mutex_clear(&g_registry_mtx);
+    }
+}

--- a/matlab/src/ufo_buffer.c
+++ b/matlab/src/ufo_buffer.c
@@ -10,6 +10,7 @@
  */
 
 #include "ufo_mex_api.h"
+#include "mexUfo_handle.h"
 #include <mex.h>
 #include <glib.h>
 #include <string.h>

--- a/matlab/src/ufo_commands.c
+++ b/matlab/src/ufo_commands.c
@@ -1,4 +1,5 @@
 #include "ufo_mex_api.h"
+#include "mexUfo_handle.h"
 #include <glib.h>
 #include <mex.h>
 
@@ -166,4 +167,33 @@ void UFO_buf_getSize(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_buf_getSize: Usage: sz = UFO_buf_getSize(bufHandle)");
     UfoBuffer *buf = getUfoHandle_Buffer(prhs[1]);
     plhs[0] = mxCreateDoubleScalar((double)ufo_buffer_get_size(buf));
+}
+
+// --------------- Task / Resources Commands ---------------
+
+void UFO_task_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+    if (nlhs != 0 || nrhs != 2)
+        mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_task_delete(task)");
+    UfoTask *task = getUfoHandle_Task(prhs[1]);
+    g_object_unref(task);
+    removeHandle(prhs[1]);
+}
+
+void UFO_res_new(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+    if (nlhs != 1 || nrhs != 1)
+        mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_res_new()");
+    GError *err = NULL;
+    UfoResources *res = ufo_resources_new(&err);
+    if (err)
+        mexErrMsgIdAndTxt("ufo_mex:ResourcesNew", "%s", err->message);
+    plhs[0] = createUfoHandle((UFO_Handle)res, "resources");
+    if (err) g_error_free(err);
+}
+
+void UFO_res_delete(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+    if (nlhs != 0 || nrhs != 2)
+        mexErrMsgIdAndTxt("ufo_mex:BadArg", "UFO_res_delete(res)");
+    UfoResources *res = getUfoHandle_Resources(prhs[1]);
+    g_object_unref(res);
+    removeHandle(prhs[1]);
 }

--- a/matlab/src/ufo_mex.c
+++ b/matlab/src/ufo_mex.c
@@ -30,12 +30,15 @@ static mexFunctionPtr find_verb(const char *name) {
         {"PluginManager_getTask", UFO_pm_getTask},
         {"PluginManager_listPlugins", NULL}, // Not implemented, placeholder
         {"PluginManager_new",  UFO_pm_new},
+        {"Resources_delete",   UFO_res_delete},
+        {"Resources_new",      UFO_res_new},
         {"Scheduler_delete",   UFO_sched_delete},
         {"Scheduler_free",     UFO_sched_delete}, // alias
         {"Scheduler_new",      UFO_sched_new},
         {"Scheduler_poll",     UFO_sched_poll},
         {"Scheduler_run",      UFO_sched_run},
         {"Scheduler_setResources", UFO_sched_setResources},
+        {"Task_delete",        UFO_task_delete},
         {"TaskGraph_connect",  UFO_tg_connect},
         {"TaskGraph_delete",   UFO_tg_delete},
         {"TaskGraph_free",     UFO_tg_delete}, // alias

--- a/matlab/ufo/Contents.m
+++ b/matlab/ufo/Contents.m
@@ -3,6 +3,8 @@
 %   ufo/PluginManager.m    High-level interface for plugin discovery & task loading.
 %   ufo/TaskGraph.m        Build & manipulate directed acyclic task graphs.
 %   ufo/Scheduler.m        Execute a TaskGraph on the available hardware.
+%   ufo/Resources.m        Hardware resource configuration object.
+%   ufo/Task.m             Wrapper for a single processing task.
 %   ufo/Buffer.m           Manage GPU/OpenCL buffers via UFO-Core.
 %
 %   For detailed help on each class:

--- a/matlab/ufo/Resources.m
+++ b/matlab/ufo/Resources.m
@@ -1,0 +1,28 @@
+classdef Resources < handle
+    properties (Access = private)
+        Handle uint64 = 0
+    end
+    methods
+        function obj = Resources()
+            obj.Handle = ufo_mex('Resources_new');
+            if obj.Handle == 0
+                error('ufo:Resources:InitFailed','Failed to create resources.');
+            end
+        end
+        function delete(obj)
+            if obj.Handle ~= 0
+                try
+                    ufo_mex('Resources_delete', obj.Handle);
+                catch ME
+                    warning('ufo:Resources:FreeFailed','Failed to free resources handle %d: %s',obj.Handle,ME.message);
+                end
+                obj.Handle = 0;
+            end
+        end
+        function assertValid(obj)
+            if obj.Handle == 0
+                error('ufo:Resources:InvalidHandle','Resources handle invalid or deleted.');
+            end
+        end
+    end
+end

--- a/matlab/ufo/Task.m
+++ b/matlab/ufo/Task.m
@@ -1,0 +1,28 @@
+classdef Task < handle
+    properties (Access = private)
+        Handle uint64 = 0
+    end
+    methods
+        function obj = Task(handle)
+            arguments
+                handle (1,1) uint64
+            end
+            obj.Handle = handle;
+        end
+        function delete(obj)
+            if obj.Handle ~= 0
+                try
+                    ufo_mex('Task_delete', obj.Handle);
+                catch ME
+                    warning('ufo:Task:FreeFailed','Failed to free Task handle %d: %s',obj.Handle,ME.message);
+                end
+                obj.Handle = 0;
+            end
+        end
+        function assertValid(obj)
+            if obj.Handle == 0
+                error('ufo:Task:InvalidHandle','Task handle is invalid or has been deleted.');
+            end
+        end
+    end
+end

--- a/tests/+ufoTest/TestBuffer.m
+++ b/tests/+ufoTest/TestBuffer.m
@@ -1,0 +1,10 @@
+classdef TestBuffer < matlab.unittest.TestCase
+    %TESTBUFFER Unit tests for ufo.Buffer basic behaviour
+    methods(Test)
+        function newGetSizeFree(testCase)
+            %TODO: create buffer via ufo.Buffer and verify size is numeric
+            %After deleting the object, any method call should error with
+            %'ufo:Buffer:InvalidHandle'.
+        end
+    end
+end

--- a/tests/+ufoTest/TestPluginManager.m
+++ b/tests/+ufoTest/TestPluginManager.m
@@ -1,0 +1,10 @@
+classdef TestPluginManager < matlab.unittest.TestCase
+    %TESTPLUGINMANAGER Validate ufo.PluginManager behaviour
+    methods(Test)
+        function listPlugins(testCase)
+            pm = ufo.PluginManager(); %#ok<NASGU>
+            %TODO: fetch plugin list via listPlugins and ensure it is a
+            %non-empty cell array of character vectors
+        end
+    end
+end

--- a/tests/+ufoTest/TestReconstructionE2E.m
+++ b/tests/+ufoTest/TestReconstructionE2E.m
@@ -1,0 +1,14 @@
+classdef TestReconstructionE2E < matlab.unittest.TestCase
+    %TESTRECONSTRUCTIONE2E End-to-end regression tests for full pipeline
+    properties(Constant)
+        DataDir = fullfile(fileparts(mfilename('fullpath')), 'data');
+    end
+    methods(Test)
+        function parallelBeam(testCase)
+            %TODO: run reconstruction on parallel-beam sample and compare
+        end
+        function fanBeam(testCase)
+            %TODO: run reconstruction on fan-beam sample and compare
+        end
+    end
+end

--- a/tests/+ufoTest/TestSchedulerIntegration.m
+++ b/tests/+ufoTest/TestSchedulerIntegration.m
@@ -1,0 +1,9 @@
+classdef TestSchedulerIntegration < matlab.unittest.TestCase
+    %TESTSCHEDULERINTEGRATION Integration test running a minimal graph
+    methods(Test)
+        function readWritePipeline(testCase)
+            %TODO: Build a read->write pipeline using temp files
+            %Run via ufo.Scheduler and check that output file exists
+        end
+    end
+end

--- a/tests/+ufoTest/TestTaskGraph.m
+++ b/tests/+ufoTest/TestTaskGraph.m
@@ -1,0 +1,13 @@
+classdef TestTaskGraph < matlab.unittest.TestCase
+    %TESTTASKGRAPH Basic validation for ufo.TaskGraph
+    methods(Test)
+        function addNodeInvalid(testCase)
+            tg = ufo.TaskGraph(); %#ok<NASGU>
+            %TODO: calling addNode with wrong type should raise an error
+        end
+        function connectBadInput(testCase)
+            tg = ufo.TaskGraph();
+            %TODO: verify connect complains on invalid endpoints
+        end
+    end
+end

--- a/tests/mex_smoke.c
+++ b/tests/mex_smoke.c
@@ -1,0 +1,21 @@
+#include "mex.h"
+
+int main(void)
+{
+    mxArray *lhs[1];
+    mxArray *rhs1[1];
+    rhs1[0] = mxCreateString("Buffer_new");
+    if (mexCallMATLAB(1, lhs, 1, rhs1, "ufo_mex"))
+        return 1;
+
+    mxArray *rhs2[2];
+    rhs2[0] = mxCreateString("Buffer_free");
+    rhs2[1] = lhs[0];
+    if (mexCallMATLAB(0, NULL, 2, rhs2, "ufo_mex"))
+        return 2;
+
+    mxDestroyArray(rhs1[0]);
+    mxDestroyArray(rhs2[0]);
+    mxDestroyArray(lhs[0]);
+    return 0;
+}

--- a/tests/runAllTests.m
+++ b/tests/runAllTests.m
@@ -1,0 +1,4 @@
+import matlab.unittest.TestSuite;
+addpath(fullfile(fileparts(mfilename('fullpath')), '..'));  % add +ufo
+results = run(TestSuite.fromPackage('ufoTest','IncludeSubpackages',true));
+assertSuccess(results);


### PR DESCRIPTION
## Summary
- provide handle helper header `mexUfo_handle.h` with typed getters and wrappers
- extend registry implementation with getters for tasks and resources and init/shutdown
- expose task/resources creation and deletion helpers in the command layer
- register new verbs in the mex dispatcher
- add MATLAB classes `ufo.Task` and `ufo.Resources`
- document new classes in `Contents.m`

## Testing
- `gcc -fsyntax-only -I. -Imatlab/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -Iufo matlab/src/mexUfo_handle.c` *(fails: mex.h missing)*
- `gcc -fsyntax-only -I. -Imatlab/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -Iufo matlab/src/ufo_commands.c` *(fails: mex.h missing)*
